### PR TITLE
Fix dynamic cut length in ExceptionShortener

### DIFF
--- a/src/Helper/ExceptionShortener.php
+++ b/src/Helper/ExceptionShortener.php
@@ -123,6 +123,6 @@ final class ExceptionShortener
             return '';
         }
 
-        return mb_strcut($string, 0, mb_strlen($string) - self::CUT_LENGTH_STEP);
+        return mb_strcut($string, 0, mb_strlen($string) - $this->cutLengthStep);
     }
 }


### PR DESCRIPTION
## Summary
- correct cut length logic in `ExceptionShortener::cutStringByStep`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml.dist tests/Helper/ExceptionShortenerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d36254f0832c8043a1d055b9b239