### PR TITLE
Add Laravel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The package could be installed with composer:
 composer require roslov/queue-bundle
 ```
 
+For Laravel applications register `Roslov\\QueueBundle\\Laravel\\QueueServiceProvider`
+in `config/app.php` and publish the configuration:
+
+```shell
+php artisan vendor:publish --provider="Roslov\\QueueBundle\\Laravel\\QueueServiceProvider"
+```
+
 Then change the default settings by creating `config/packages/roslov_queue.yaml` with the content below.
 
 ```yaml

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/orm": "^2.11|^3.0",
         "php-amqplib/rabbitmq-bundle": "^2.12",
         "roslov/log-obfuscator": "^1.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "symfony/config": "^6.0|^7.0",
         "symfony/dependency-injection": "^6.0|^7.0",
         "symfony/framework-bundle": "^6.0|^7.0",
@@ -28,7 +29,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Roslov\\QueueBundle\\": "src"
+            "Roslov\\QueueBundle\\": "src",
+            "Roslov\\QueueBundle\\Laravel\\": "src/Laravel"
         }
     },
     "autoload-dev": {

--- a/src/Laravel/QueueServiceProvider.php
+++ b/src/Laravel/QueueServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roslov\QueueBundle\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use Roslov\QueueBundle\Helper\ExceptionShortener;
+use Roslov\QueueBundle\Producer\ProducerFacade;
+use Roslov\QueueBundle\Sender\ExceptionSender;
+
+/**
+ * Laravel service provider for the queue package.
+ */
+class QueueServiceProvider extends ServiceProvider
+{
+    /**
+     * Register bindings in the container.
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/config/roslov_queue.php', 'roslov_queue');
+
+        $this->app->singleton(ExceptionShortener::class, function () {
+            return new ExceptionShortener();
+        });
+
+        $this->app->singleton(ExceptionSender::class, function ($app) {
+            return new ExceptionSender(
+                $app->make(ProducerFacade::class),
+                $app->make(ExceptionShortener::class),
+                config('roslov_queue.service_name', 'service')
+            );
+        });
+    }
+
+    /**
+     * Perform post-registration booting of services.
+     */
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__ . '/config/roslov_queue.php' => config_path('roslov_queue.php'),
+        ], 'config');
+    }
+}

--- a/src/Laravel/config/roslov_queue.php
+++ b/src/Laravel/config/roslov_queue.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'service_name' => env('ROSLOV_QUEUE_SERVICE_NAME', 'my_service'),
+    'ssl_enabled' => env('ROSLOV_QUEUE_SSL_ENABLED', false),
+    'logger' => env('ROSLOV_QUEUE_LOGGER', 'logger'),
+    'entity_manager' => env('ROSLOV_QUEUE_ENTITY_MANAGER', null),
+    'payload_mapping' => [
+        'Error' => Roslov\QueueBundle\Dto\Error::class,
+        'Trigger' => Roslov\QueueBundle\Dto\Trigger::class,
+        'Response.Empty' => Roslov\QueueBundle\Dto\EmptyResponse::class,
+        'Exception.Thrown' => Roslov\QueueBundle\Dto\ExceptionThrown::class,
+    ],
+    'event_processor' => [
+        'enabled' => false,
+        'instant_delivery' => true,
+        'delayed_delivery_subscriber' => true,
+    ],
+    'exception_subscriber' => [
+        'enabled' => false,
+        'exception_validator' => null,
+    ],
+    'exception_sender' => [
+        'connection' => 'default',
+        'exchange_options' => [
+            'name' => 'default',
+            'type' => 'topic',
+        ],
+    ],
+    'rpc_client' => [
+        'enabled' => false,
+        'connection' => 'default',
+    ],
+    'rpc_server' => [
+        'enabled' => false,
+        'connection' => 'default',
+        'exchange' => 'rpc_exchange',
+        'setup' => null,
+        'handlers' => [],
+    ],
+];


### PR DESCRIPTION
## Summary
- register Laravel service provider and config
- publish config instructions in README
- require illuminate/support in composer.json
- add PSR-4 autoload for Laravel

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6849d3bc1aac832cb1fb1e5bb7c4aa87